### PR TITLE
feat: 価格影響の表示と警告機能を追加

### DIFF
--- a/gswap/src/app/globals.css
+++ b/gswap/src/app/globals.css
@@ -174,3 +174,26 @@ a {
 .mb-4 {
   margin-bottom: 1rem;
 }
+
+/* src/app/globals.css */
+
+/* ... 既存のCSS ... */
+
+.price-impact-low {
+  color: #a0aec0; /* gray-400 */
+}
+
+.price-impact-medium {
+  color: #f6ad55; /* orange-400 */
+}
+
+.price-impact-high {
+  color: #e53e3e; /* red-600 */
+  font-weight: bold;
+}
+
+.warning-message {
+  color: #e53e3e; /* red-600 */
+  font-size: 0.75rem; /* text-xs */
+  margin-top: 0.5rem;
+}

--- a/gswap/src/hooks/useSolanaConnection.ts
+++ b/gswap/src/hooks/useSolanaConnection.ts
@@ -1,0 +1,83 @@
+// src/hooks/useSolanaConnection.ts
+import { useState, useEffect, useCallback } from 'react';
+import { Connection } from '@solana/web3.js';
+import { toast } from 'react-hot-toast';
+import { SOLANA_RPC_URLS, SOLANA_CLUSTER } from '../utils/constants'; // SOLANA_CLUSTERもインポート
+
+interface UseSolanaConnection {
+  connection: Connection | null;
+  currentRpcUrl: string | null;
+  isConnected: boolean;
+  error: string | null;
+  setConnection: (url: string) => void;
+  reconnect: () => void;
+}
+
+export const useSolanaConnection = (): UseSolanaConnection => {
+  const [connection, setConnectionState] = useState<Connection | null>(null);
+  const [currentRpcUrl, setCurrentRpcUrl] = useState<string | null>(null);
+  const [isConnected, setIsConnected] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [currentRpcIndex, setCurrentRpcIndex] = useState(0);
+
+  const establishConnection = useCallback(async (url: string) => {
+    try {
+      // clusterApiUrlは使わず、直接URLを指定
+      const newConnection = new Connection(url, 'confirmed');
+      const health = await newConnection.getHealth();
+      if (health === 'ok') {
+        setConnectionState(newConnection);
+        setCurrentRpcUrl(url);
+        setIsConnected(true);
+        setError(null);
+        toast.success(`RPC接続に成功しました: ${url}`);
+        return true;
+      }
+      return false;
+    } catch (err: any) {
+      console.error(`Failed to connect to RPC: ${url}`, err);
+      setError(`RPC接続エラー: ${url} (${err.message})`);
+      setIsConnected(false);
+      return false;
+    }
+  }, []);
+
+  const setConnection = useCallback((url: string) => {
+    setCurrentRpcUrl(url); // 選択されたURLを保持
+    setConnectionState(new Connection(url, 'confirmed')); // 新しいConnectionインスタンスを作成
+    setIsConnected(false); // 再接続が必要になるためfalseに
+    establishConnection(url); // 新しいURLで接続を試みる
+  }, [establishConnection]);
+
+  const reconnect = useCallback(async () => {
+    setError(null);
+    setIsConnected(false);
+    let connected = false;
+    // SOLANA_RPC_URLSが空の場合に備える
+    if (SOLANA_RPC_URLS.length === 0) {
+      toast.error('RPCエンドポイントが設定されていません。');
+      setError('RPCエンドポイントが設定されていません。');
+      return;
+    }
+
+    for (let i = 0; i < SOLANA_RPC_URLS.length; i++) {
+      const url = SOLANA_RPC_URLS[(currentRpcIndex + i) % SOLANA_RPC_URLS.length];
+      toast.loading(`RPCを試行中: ${url}...`, { id: 'rpc-connect' });
+      connected = await establishConnection(url);
+      toast.dismiss('rpc-connect');
+      if (connected) {
+        setCurrentRpcIndex((currentRpcIndex + i) % SOLANA_RPC_URLS.length);
+        break;
+      }
+    }
+    if (!connected) {
+      toast.error('全てのRPC接続に失敗しました。');
+    }
+  }, [currentRpcIndex, establishConnection]);
+
+  useEffect(() => {
+    reconnect(); // コンポーネントマウント時に初期接続を試みる
+  }, [reconnect]);
+
+  return { connection, currentRpcUrl, isConnected, error, setConnection, reconnect };
+};

--- a/gswap/src/hooks/useTokenBalance.ts
+++ b/gswap/src/hooks/useTokenBalance.ts
@@ -1,0 +1,69 @@
+// src/hooks/useTokenBalance.ts
+import { useState, useEffect, useCallback } from 'react';
+import { PublicKey } from '@solana/web3.js';
+import { useWallet } from '@solana/wallet-adapter-react';
+import { useSolanaConnection } from './useSolanaConnection'; // カスタムConnectionフック
+import { getAssociatedTokenAddressSync, getAccount } from '@solana/spl-token'; // SPLトークン残高取得用
+
+interface UseTokenBalance {
+  balance: number | null;
+  isLoading: boolean;
+  error: string | null;
+  refetchBalance: () => void;
+}
+
+export const useTokenBalance = (tokenMintAddress: string | null): UseTokenBalance => {
+  const { publicKey } = useWallet();
+  const { connection } = useSolanaConnection();
+  const [balance, setBalance] = useState<number | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchBalance = useCallback(async () => {
+    if (!publicKey || !connection || !tokenMintAddress) {
+      setBalance(null);
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const mintPublicKey = new PublicKey(tokenMintAddress);
+
+      // SOLの場合 (ネイティブSOLとWSOL両方に対応)
+      if (tokenMintAddress === 'So11111111111111111111111111111111111111112' || tokenMintAddress === 'SOL') { // 'SOL' symbol support
+        const lamports = await connection.getBalance(publicKey);
+        setBalance(lamports / 10 ** 9); // SOLは9桁
+      } else {
+        // SPLトークンの場合
+        const associatedTokenAccount = getAssociatedTokenAddressSync(mintPublicKey, publicKey);
+        const accountInfo = await connection.getAccountInfo(associatedTokenAccount);
+
+        if (accountInfo) {
+          const tokenAccount = await getAccount(connection, associatedTokenAccount);
+          setBalance(Number(tokenAccount.amount) / (10 ** tokenAccount.mint.decimals)); // トークンのdecimalsを使用
+        } else {
+          setBalance(0); // ATAがない場合は残高0
+        }
+      }
+    } catch (err: any) {
+      console.error(`Failed to fetch balance for ${tokenMintAddress}:`, err);
+      setError(`残高取得エラー: ${err.message}`);
+      setBalance(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [publicKey, connection, tokenMintAddress]);
+
+  useEffect(() => {
+    fetchBalance();
+    // ウォレット接続やRPC変更時にも残高を更新
+    // リアルタイム更新のため、Account subscriptionも検討可能ですが、今回はシンプルに再フェッチ
+    const interval = setInterval(fetchBalance, 15000); // 15秒ごとに残高を更新
+    return () => clearInterval(interval);
+  }, [fetchBalance]);
+
+  return { balance, isLoading, error, refetchBalance: fetchBalance };
+};

--- a/gswap/src/hooks/useTransactionWatcher.ts
+++ b/gswap/src/hooks/useTransactionWatcher.ts
@@ -1,0 +1,96 @@
+// src/hooks/useTransactionWatcher.ts
+import { useCallback } from 'react';
+import { Connection, SignatureResult, TransactionResponse, TransactionSignature } from '@solana/web3.js';
+import { toast } from 'react-hot-toast';
+import { SOLANA_CLUSTER } from '../utils/constants'; // Solana Clusterをインポート
+import React from 'react'; // Reactをインポート
+
+interface UseTransactionWatcher {
+  watchTransaction: (signature: TransactionSignature, connection: Connection) => void;
+}
+
+export const useTransactionWatcher = (): UseTransactionWatcher => {
+
+  const watchTransaction = useCallback((signature: TransactionSignature, connection: Connection) => {
+    let toastId: string | undefined;
+
+    const showTransactionToast = (status: 'pending' | 'success' | 'failed', txId: string) => {
+      const explorerLink = `https://solana.fm/tx/${txId}?cluster=${SOLANA_CLUSTER}`;
+      if (toastId) {
+        toast.dismiss(toastId);
+      }
+      switch (status) {
+        case 'pending':
+          toastId = toast.loading(
+            // JSXを直接渡すのではなく、React.createElementを使用するか、
+            // よりシンプルなテンプレートリテラルで記述
+            // エラー箇所の '...' は改行後のスペースやタブによるものかもしれません
+            // 以下のように、改行を除去するか、React.Fragmentを使用する
+            React.createElement('span', null, 
+              'トランザクションを処理中...', 
+              React.createElement('br'),
+              React.createElement('a', { 
+                href: explorerLink, 
+                target: '_blank', 
+                rel: 'noopener noreferrer', 
+                className: 'text-blue-400 underline' 
+              }, '確認する')
+            ),
+            { duration: Infinity }
+          );
+          break;
+        case 'success':
+          toastId = toast.success(
+            React.createElement('span', null, 
+              'トランザクションが承認されました！', 
+              React.createElement('br'),
+              React.createElement('a', { 
+                href: explorerLink, 
+                target: '_blank', 
+                rel: 'noopener noreferrer', 
+                className: 'text-blue-400 underline' 
+              }, 'SolanaFMで確認')
+            ),
+            { duration: 8000 }
+          );
+          break;
+        case 'failed':
+          toastId = toast.error(
+            React.createElement('span', null, 
+              'トランザクションに失敗しました。', 
+              React.createElement('br'),
+              React.createElement('a', { 
+                href: explorerLink, 
+                target: '_blank', 
+                rel: 'noopener noreferrer', 
+                className: 'text-blue-400 underline' 
+              }, '詳細を見る')
+            ),
+            { duration: 10000 }
+          );
+          break;
+      }
+    };
+
+    // 初期状態を保留中で表示
+    showTransactionToast('pending', signature);
+
+    // トランザクションの確認を待つ
+    connection.confirmTransaction(signature, 'confirmed')
+      .then((confirmation) => {
+        if (confirmation.value.err) {
+          console.error('Transaction failed:', confirmation.value.err);
+          showTransactionToast('failed', signature);
+        } else {
+          showTransactionToast('success', signature);
+        }
+      })
+      .catch((error) => {
+        console.error('Transaction confirmation error:', error);
+        showTransactionToast('failed', signature);
+      });
+
+  }, []);
+
+  return { watchTransaction };
+};

--- a/gswap/src/utils/constants.ts
+++ b/gswap/src/utils/constants.ts
@@ -2,6 +2,13 @@
 
 // .env.localから環境変数を読み込む
 // Next.jsでは、NEXT_PUBLIC_プレフィックスを付けることでクライアントサイドでも利用可能
-export const SOLANA_RPC_URL = process.env.NEXT_PUBLIC_SOLANA_RPC_URL || 'https://api.devnet.solana.com';
+
+// 複数のRPCエンドポイントを配列で定義し、環境変数があればそれを使用する
+export const SOLANA_RPC_URLS = [
+  process.env.NEXT_PUBLIC_SOLANA_RPC_URL_MAINNET_1 || 'https://api.mainnet-beta.solana.com',
+  process.env.NEXT_PUBLIC_SOLANA_RPC_URL_MAINNET_2 || 'https://solana-api.projectserum.com', // 例として別のRPCプロバイダ
+  process.env.NEXT_PUBLIC_SOLANA_RPC_URL_DEVNET || 'https://api.devnet.solana.com', // 開発用
+].filter(Boolean); // undefined や null を取り除く
+
 export const JUPITER_API_KEY = process.env.NEXT_PUBLIC_JUPITER_API_KEY; // Jupiter API Key (もし必要なら)
-export const SOLANA_CLUSTER = process.env.NEXT_PUBLIC_SOLANA_CLUSTER || 'devnet'; // "devnet", "mainnet-beta"など
+export const SOLANA_CLUSTER = process.env.NEXT_PUBLIC_SOLANA_CLUSTER || 'mainnet-beta'; // "devnet", "mainnet-beta"など


### PR DESCRIPTION
これ出来てますか？
長文なのでAIに要約してもらってください

変更点は
1,useSolanaConnection.ts , useTransactionWatcher.ts , useTokenBalance.tsを新規作成
2,constants.ts の変更
3,SwapForm.tsx の変更
4,globals.css の変更

1
useSolanaConnection.tsは、RPCエンドポイントの選択とフォールバックロジックをカプセル化するカスタムフック
(「Webアプリケーションが、遠くのサーバーに何かをお願いする（RPCリクエストを送る）際に、どのサーバーに送るか（エンドポイントの選択）と、もしそのサーバーがダメだった場合に別のサーバーに切り替える（フォールバック）という一連の複雑な処理を、開発者が簡単に使えるようにまとめた道具箱（カスタムフック）のこと」)

useTransactionWatcher.tsは、これはトランザクションの署名を監視し、ステータスをリアルタイムでユーザーに通知するカスタムフック

useTokenBalance.tsは、接続されているウォレットの特定のトークン（SOLとSPLトークン）の残高を取得・表示するカスタムフック

2
単一の SOLANA_RPC_URL ではなく、複数のRPCエンドポイントを管理するための配列 SOLANA_RPC_URLS を定義するように変更した。

環境変数が存在しない場合に備えて、デフォルトのRPC URLが設定されるようにした。

SOLANA_RPC_URLS の配列が undefined や null の要素を含まないように .filter(Boolean) を追加した。

SOLANA_CLUSTER および JUPITER_API_KEY も環境変数から読み込むようにした。

3
useSolanaConnection、useTokenBalance、useTransactionWatcher の各カスタムフックをインポートし、利用するように変更し
た。
Jupiter APIの見積もり応答から priceImpactPct を取得し、それを基に価格影響度（Price Impact）を計算・表示するロジックを追加した。

価格影響度が特定の閾値を超えた場合に警告メッセージと色分け（CSSクラス price-impact-low, price-impact-medium, price-impact-high, warning-message）を表示する機能を追加した
。
ウォレットに接続されたトークンの残高をリアルタイムで表示する機能を追加した?(ごめんこれはわかんない
)
MAX ボタンを追加し、ウォレット内のFromトークンの最大残高（SOLの場合は手数料を考慮）を自動入力する機能を追加した。(25%刻みで欲しいね)

スワップ実行後、useTransactionWatcher を用いてトランザクションのステータスを監視し、リアルタイム通知（保留中、承認済み、失敗）を行うようにした。SolanaFMへのリンクも通知に含まれる。

トランザクション送信時の sendTransaction メソッドに connection オブジェクトを渡すように変更した。

4
価格影響度表示のためのCSSクラス (.price-impact-low, .price-impact-medium, .price-impact-high, .warning-message) を追加
